### PR TITLE
added a 'name' prop

### DIFF
--- a/src/star-ratings.js
+++ b/src/star-ratings.js
@@ -121,7 +121,7 @@ class StarRatings extends React.Component {
         <Star
           key={starRating}
           fillId={this.fillId}
-          changeRating={changeRating ? () => changeRating(name, starRating) : null}
+          changeRating={changeRating ? () => changeRating(starRating, name) : null}
           hoverOverStar={changeRating ? this.hoverOverStar(starRating) : null}
           unHoverOverStar={changeRating ? this.unHoverOverStar : null}
           isStarred={isStarred}

--- a/src/star-ratings.js
+++ b/src/star-ratings.js
@@ -94,7 +94,8 @@ class StarRatings extends React.Component {
       gradientPathName,
       ignoreInlineStyles,
       svgIconPath,
-      svgIconViewBox
+      svgIconViewBox,
+      name
     } = this.props;
     const { highestStarHovered } = this.state;
         
@@ -120,7 +121,7 @@ class StarRatings extends React.Component {
         <Star
           key={starRating}
           fillId={this.fillId}
-          changeRating={changeRating ? () => changeRating(starRating) : null}
+          changeRating={changeRating ? () => changeRating(name, starRating) : null}
           hoverOverStar={changeRating ? this.hoverOverStar(starRating) : null}
           unHoverOverStar={changeRating ? this.unHoverOverStar : null}
           isStarred={isStarred}
@@ -188,6 +189,7 @@ StarRatings.propTypes = {
   ignoreInlineStyles: PropTypes.bool.isRequired,
   svgIconPath: PropTypes.string.isRequired,
   svgIconViewBox: PropTypes.string.isRequired,
+  name: PropTypes.string
 };
 
 StarRatings.defaultProps = {


### PR DESCRIPTION
added a 'name' prop to make the star-rating div identifiable. In case we have more than one star-rating component in the code, there is no way to differentiate between them. By adding 'name' prop one can make out which star-rating component is being changed inside the changeRating event. @ekeric13 