### PR TITLE
Fix invalid babelrc file

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,9 +4,6 @@
     "react",
     "stage-0"
   ],
-  "plugins": [
-    
-  ],
   "env": {
     "development": {
       "plugins": [


### PR DESCRIPTION
An empty array as plugins isn't allowed in a babelrc file. This PR removes it as it breaks some build tools