### PR TITLE
Remove .babelrc from published module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ node_modules/
 npm-debug.log
 test/
 example/
+.babelrc


### PR DESCRIPTION
Remove .babelrc from published module as it causes issues with bundlers that don't recognise it's config format. (Parcel.js)