### PR TITLE
Add TypeScript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.3.0",
   "description": "A customizable star rating component for selecting x stars or visualizing x stars",
   "main": "build/index.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "make build"
@@ -40,6 +41,7 @@
     ]
   },
   "devDependencies": {
+    "@types/react": "^16.1.0",
     "react-fatigue-dev": "github:ekeric13/react-fatigue-dev"
   },
   "dependencies": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,42 @@
+import * as React from 'react';
+
+export interface ChangeRatingHandler {
+    (rating: number, name?: string): void;
+}
+
+export interface StarRatingsProps {
+    rating: number;
+    typeOfWidget: string;
+    numberOfStars: number;
+    changeRating: ChangeRatingHandler | null;
+    starHoverColor: string;
+    starRatedColor: string;
+    starEmptyColor: string;
+    starDimension: string;
+    starSpacing: string;
+    gradientPathName: string;
+    ignoreInlineStyles: boolean;
+    svgIconPath: string;
+    svgIconViewBox: string;
+    name?: string;
+}
+
+class StarRatings extends React.Component<StarRatingsProps> {
+    static defaultProps = {
+        rating: 0,
+        typeOfWidget: 'Star',
+        numberOfStars: 5,
+        changeRating: null,
+        starHoverColor: 'rgb(230, 67, 47)',
+        starRatedColor: 'rgb(109, 122, 130)',
+        starEmptyColor: 'rgb(203, 211, 227)',
+        starDimension: '50px',
+        starSpacing: '7px',
+        gradientPathName: '',
+        ignoreInlineStyles: false,
+        svgIconPath: 'm25,1 6,17h18l-14,11 5,17-15-10-15,10 5-17-14-11h18z',
+        svgIconViewBox: '0 0 51 48'
+    }
+}
+
+export default StarRatings;


### PR DESCRIPTION
This PR adds typings to allow for an easier integration in TypeScript based projects. 

All types are extracted from the source files and the documentation. Here the values found in the source code take precedence. For example the type of the `changeRating` handler is `((rating, name?) => void) | null` with a default of `null` instead of `() => {}` like stated in the documentation.

This also fixes #10 in TypeScript projects, because I added the corresponding property to the component, since the feature is already implemented but the propTypes lack the correspondig property whilst its default is set to `Star`.