### PR TITLE
Use inline-flex to remove awkward padding

### DIFF
--- a/src/star-ratings.js
+++ b/src/star-ratings.js
@@ -12,7 +12,7 @@ class StarRatings extends React.Component {
     const starRatingsStyle = {
       position: 'relative',
       boxSizing: 'border-box',
-      display: 'inline-block'
+      display: 'inline-flex'
     };
     return this.props.ignoreInlineStyles ? {} : starRatingsStyle;
   }

--- a/test/src/star.js
+++ b/test/src/star.js
@@ -15,7 +15,7 @@ class Star extends React.Component {
 
     const starContainerStyle = {
       position: 'relative',
-      display: 'inline-block',
+      display: 'flex',
       verticalAlign: 'middle',
       paddingLeft: isFirstStar ? undefined : starSpacing,
       paddingRight: isLastStar ? undefined : starSpacing,


### PR DESCRIPTION
StarContainer used to have an awkward padding with style `inline-block`.
![image](https://user-images.githubusercontent.com/17506890/67446562-9ab05580-f643-11e9-8278-977007c4b591.png)

I've changed it to `flex` and used `inline-flex` on its container to remove the padding.
![image](https://user-images.githubusercontent.com/17506890/67446728-22965f80-f644-11e9-98ba-fc7e27d19f57.png)
